### PR TITLE
Add raise (inverse of lower)

### DIFF
--- a/src/IRViz.jl
+++ b/src/IRViz.jl
@@ -1,7 +1,8 @@
 module IRViz
 using Kroki
-export viz
+export viz, raise
 
 include("code-flow-graph.jl")
+include("raise.jl")
 
 end

--- a/src/raise.jl
+++ b/src/raise.jl
@@ -1,0 +1,85 @@
+using Core.Compiler: IRCode
+using Core: SSAValue
+using Base.Meta: isexpr
+function raise(ir::IRCode)
+    ir = copy(ir)
+    ssa_used_in = ssa_use_graph(ir)
+    out_stmts = Vector()
+    for ii in length(ir.stmts):-1:1
+        stmt_ssa = SSAValue(ii)
+        new_stmt = raise!(ir, ssa_used_in, stmt_ssa)
+        isnothing(new_stmt) && continue
+        pushfirst!(out_stmts, stmt_ssa => new_stmt)
+    end
+    return out_stmts
+end
+
+function raise!(ir::IRCode, ssa_used_in, ssa::SSAValue)
+    stmt = ir[ssa].stmt
+    new_stmt = if isexpr(stmt, :call)
+        raise_call_or_invoke!(ir, ssa_used_in, stmt.args...)
+    elseif isexpr(stmt, :invoke) 
+        raise_call_or_invoke!(ir, ssa_used_in, stmt.args[2:end]...)
+    else
+        stmt
+    end
+    ir[ssa].stmt = nothing
+    return new_stmt
+end
+
+function raise_call_or_invoke!(ir::IRCode, ssa_used_in, f, args...)
+    head = raise_function_ref(f)
+    if head == :getfield
+        return Expr(:., args[1], args[2])
+    end
+    args = map(args) do arg
+        if (arg isa SSAValue)
+            uses = ssa_used_in[arg]
+            if length(uses) == 1  # Proactively raise it here, inline
+                return raise!(ir, ssa_used_in, arg)
+            end
+        end
+        return arg
+    end
+    Expr(:call, head, args...)
+end
+function raise_function_ref(head::GlobalRef)
+    (;name, mod) = head   
+    if mod == Base
+        name = if name ∈ (:div_float, :div_int)
+            :/
+        elseif name ∈ (:mul_float, :mul_int)
+            :*
+        elseif name ∈ (:sub_float, :sub_int, :neg_float, :neg_int)
+            :-
+        elseif name ∈ (:add_float, :add_int)
+            :+
+        else 
+            name
+        end
+    end
+    return name  # just drop the module name
+end
+raise_function_ref(head::Function) = nameof(head)
+raise_function_ref(head) = head
+
+function ssa_use_graph(ir::IRCode)
+    used_in = Dict{SSAValue, Vector{SSAValue}}()
+    sizehint!(used_in, length(ir.stmts))
+    for ii in 1:length(ir.stmts)
+        stmt_ssa = SSAValue(ii)
+        stmt = ir[stmt_ssa].stmt
+        if stmt isa Expr
+            for arg in stmt.args
+                if arg isa SSAValue
+                    @assert arg < stmt_ssa
+                    uses = get!(Vector{SSAValue}, used_in, arg)
+                    push!(uses, stmt_ssa)
+                end
+            end
+        end
+    end
+    return used_in
+end
+
+raise(ir)

--- a/src/raise.jl
+++ b/src/raise.jl
@@ -72,7 +72,7 @@ function ssa_use_graph(ir::IRCode)
         if stmt isa Expr
             for arg in stmt.args
                 if arg isa SSAValue
-                    @assert arg < stmt_ssa
+                    @assert arg.id < stmt_ssa.id
                     uses = get!(Vector{SSAValue}, used_in, arg)
                     push!(uses, stmt_ssa)
                 end


### PR DESCRIPTION
This is an attempt to make for more readable SSA form IR for debugging purposes.
Main feature is to colapse into single expressions long chains of single use statements.
The result is not eval-able and that is not the goal

I may or may not finish this depending how useful it is to others.
Given It is almost useful enough for my purposes already.

In order to finish:

- [ ] handle `goto`s and `gotoifnot`s, right now we totally screw them up and ignore them from ssa use graph
- [ ] collapse though statements like `%2=%1`
- [ ] tests



This is example of its use
input:
```llvm
julia> ir
106 1 ──       (DAECompiler.Intrinsics.solved_variable)(2, 0.0)::Nothing╷╷╷╷    #2
104 │    %2  = invoke DAECompiler.sim_time()::Incidence(1.0t)       │          
105 │    %3  = Base.getfield(_1, :mode)::Incidence(Symbol, )        │╻          getproperty
106 │    %4  = 0.0::Core.Const(0.0)                                 │╻╷╷╷╷╷╷    #2
    │    %5  = (%3 === :dcop)::Incidence(Bool, )                    ││╻╷╷        macro expansion
    │    %6  = (%3 === :tranop)::Incidence(Bool, )                  │││┃││││      ckt_##circuit#202
    │    %7  = (Core.ifelse)(%6, 0.0, %2)::Incidence(f(t))          ││││┃││        #ckt_##circuit#202#1
    │    %8  = (Core.ifelse)(%5, 0.0, %7)::Incidence(f(t))          │││││┃│         spsin
    │    %9  = %8::Incidence(f(t))                                  ││││││┃          spsin
    │    %10 = invoke CedarSim.SpectreEnvironment.:<(%9::Float64, 0::Int64)::Incidence(Bool, f(t))
    │    %11 = (%3 === :dcop)::Incidence(Bool, )                    │││││││╻          $time
    │    %12 = (%3 === :tranop)::Incidence(Bool, )                  ││││││││   
    │    %13 = (Core.ifelse)(%12, 0.0, %2)::Incidence(f(t))         │││││││    
    │    %14 = (Core.ifelse)(%11, 0.0, %13)::Incidence(f(t))        │││││││    
    │    %15 = %14::Incidence(f(t))                                 │││││││    
    │    %16 = invoke CedarSim.SpectreEnvironment.:-(%15::Float64, 0::Int64)::Incidence(f(t))
    │    %17 = invoke CedarSim.SpectreEnvironment.:*(360::Int64, 1000.0::Float64, %16::Float64)::Incidence(f(t))
    │    %18 = invoke CedarSim.SpectreEnvironment.:+(%17::Float64, 0::Int64)::Incidence(f(t))
    │    %19 = invoke Base.sind(%18::Float64)::Incidence(Float64, f(t))││││    
    │    %20 = invoke CedarSim.SpectreEnvironment.:*(1::Int64, 1.0::Float64, %19::Float64)::Incidence(Float64, f(t))
    │    %21 = invoke CedarSim.SpectreEnvironment.:+(0.5::Float64, %20::Float64)::Incidence(Float64, f(t))
    │    %22 = (Core.ifelse)(%10, 0.5, %21)::Incidence(Float64, f(t))│││││     
    │    %23 = %22::Incidence(Float64, f(t))                        ││││││     
    │    %24 = invoke CedarSim.:-(%4::Float64, 0.0::Float64)::Core.Const(0.0)╷       ParallelInstances
    │    %25 = (%3 === :dcop)::Incidence(Bool, )                    │││││││╻          VoltageSource
    │    %26 = (Core.ifelse)(%25, 0.0, %23)::Incidence(Float64, f(t))│││││││┃│         branch!
    │    %27 = %26::Incidence(Float64, f(t))                        │││││││││┃          #93
    │    %28 = invoke CedarSim.:-(%24::Float64, %27::Float64)::Float64││││││││ 
    │          nothing::DAECompiler.Eq(5)                           ││││││││││╻          equation!
    │    %30 = (/)(%28, -1.0)::Any                                  │││││││││││
    │          (DAECompiler.Intrinsics.solved_variable)(1, %30)::Nothing│││││││
    │    %32 = Base.getfield(_1, :params)::Incidence(CedarSim.VectorPrisms.VectorPrism{Float64, @NamedTuple{cap_dummy::Float64, r1::Float64, r2::Float64}}, )
    │    %33 = CedarSim.getfield(%32, :backing)::Incidence(@NamedTuple{cap_dummy::Float64, r1::Float64, r2::Float64}, )
    │    %34 = Base.getfield(%33, :r1)::Incidence(Float64, )        ││╻╷╷╷╷╷╷╷   macro expansion
    │    %35 = invoke DAECompiler.Intrinsics.variable(nothing::DAECompiler.Intrinsics.Scope)::Incidence(u₄)
    │    %36 = %35::Incidence(u₄)                                   ││││┃│││       #ckt_##circuit#202#1
    │    %37 = 0.0::Core.Const(0.0)                                 │││││╻╷╷╷╷      Named
    │    %38 = invoke CedarSim.:-(%30::Float64, %36::Float64)::Float64││││┃│││       ParallelInstances
    │    %39 = invoke CedarSim.:/(%38::Float64, %34::Float64)::Float64│││││╻          SimpleResistor
    │    %40 = invoke CedarSim.:-(%37::Float64, %39::Float64)::Float64││││││┃│         branch!
    │          nothing::DAECompiler.Eq(6)                           │││││││││╻          equation!
    │    %42 = (/)(%40, -1.0)::Any                                  ││││││││││┃          equation!
    │          (DAECompiler.Intrinsics.solved_variable)(6, %42)::Nothing│││││││
    │    %44 = (*)(1.0, %42)::Any                                   │││││╻╷╷        Named
    │    %45 = (/)(%44, -1.0)::Any                                  ││││││┃│         IRNet
    │          (DAECompiler.Intrinsics.solved_variable)(5, %45)::Nothing│││┃          IRNet
    │    %47 = Base.getfield(%33, :r2)::Incidence(Float64, )        │││││╻╷╷╷╷      ParamLens
    │    %48 = 0.0::Core.Const(0.0)                                 │││││╻╷╷╷╷      Named
    │    %49 = invoke CedarSim.:-(%36::Float64, 0.0::Float64)::Incidence(u₄)││       ParallelInstances
    │    %50 = invoke CedarSim.:/(%49::Float64, %47::Float64)::Float64│││││╻          SimpleResistor
    │    %51 = invoke CedarSim.:-(%48::Float64, %50::Float64)::Float64││││││┃│         branch!
    │          nothing::DAECompiler.Eq(7)                           │││││││││╻          equation!
    │    %53 = (/)(%51, -1.0)::Any                                  ││││││││││┃          equation!
    │          (DAECompiler.Intrinsics.solved_variable)(7, %53)::Nothing│││││││
    │    %55 = (*)(-1.0, %42)::Any                                  │││││╻╷╷        Named
    │    %56 = (*)(1.0, %53)::Any                                   ││││││┃│         IRNet
    │    %57 = (+)(%55, %56)::Any                                   │││││││┃          IRNet
    │    %58 = (/)(%57, -1.0)::Any                                  ││││││││   
    │          (DAECompiler.Intrinsics.solved_variable)(3, %58)::Nothing││││   
    │    %60 = (*)(-1.0, %42)::Any                                  │││││╻╷╷        Named
    │    %61 = (*)(1.0, %53)::Any                                   ││││││┃│         IRNet
    │    %62 = (+)(%60, %61)::Any                                   │││││││┃          IRNet
    │          nothing::DAECompiler.Eq(1)                           │││││╻╷╷        Named
    │          nothing::DAECompiler.Eq(2)                           │││││╻╷╷        Named
    │          nothing::Float64                                     │││││╻╷╷        Named
    │          nothing::Core.Const(0.0)                             ││││││╻          Gnd
    │          nothing::DAECompiler.Eq(3)                           │││││││╻          equation!
    │    %68 = invoke CedarSim.equation(nothing::DAECompiler.Intrinsics.Scope)::DAECompiler.Eq(4)
    │          (%68)(%62)::Nothing                                  │││││││┃          IRNet
    └───       goto #3 if not %5                                    │││││╻╷╷        spsin
    2 ──       goto #6                                              ││││││┃│         spsin
    3 ──       goto #5 if not %6                                    │││││││┃          $time
    4 ──       goto #6                                              ││││││││   
    5 ──       goto #6                                              ││││││││   
    6 ┄─       goto #8 if not %10                                   │││││││    
    7 ──       goto #14                                             │││││││    
    8 ──       goto #10 if not %11                                  │││││││╻          $time
    9 ──       goto #13                                             ││││││││   
    10 ─       goto #12 if not %12                                  ││││││││   
    11 ─       goto #13                                             ││││││││   
    12 ─       goto #13                                             ││││││││   
    13 ┄       goto #14                                             │││││││    
    14 ┄       nothing::Float64                                     ││││││╻╷╷╷       ParallelInstances
    │          nothing::Float64                                     │││││││┃│││       VoltageSource
    │          nothing::Float64                                     ││││││││╻          branch!
    │    %86 = invoke CedarSim.:-(%30::Float64, 0.0::Float64)::Float64│││││││╻          branch!
    │          invoke CedarSim.observed!(%86::Float64, nothing::DAECompiler.Intrinsics.Scope, 1)::Any
    └───       goto #16 if not %25                                  │││││││││╻          #93
    15 ─       goto #17                                             ││││││││││ 
    16 ─       nothing::Nothing                                     │          
    17 ┄       nothing::Float64                                     ││││││││││ 
    │          nothing::Float64                                     │││││╻╷╷╷╷      Named
    │          nothing::Float64                                     ││││││┃││││      ParallelInstances
    │          nothing::Float64                                     │││││││╻          SimpleResistor
    │          invoke CedarSim.observed!(%38::Float64, nothing::DAECompiler.Intrinsics.Scope, 2)::Any
    │          nothing::Float64                                     │││││││││╻          #74
    │          nothing::Float64                                     │││││╻╷╷╷╷      Named
    │          nothing::Float64                                     ││││││┃││││      ParallelInstances
    │          nothing::Float64                                     │││││││╻          SimpleResistor
    │          invoke CedarSim.observed!(%49::Float64, nothing::DAECompiler.Intrinsics.Scope, 3)::Any
    │          nothing::Float64                                     │││││││││╻          #74
    └───       return nothing                                       │          
                
```

output:
```julia
julia> raise(ir)
42-element Vector{Any}:
   :(%1) => :(solved_variable(2, 0.0))
   :(%2) => :(sim_time())
   :(%3) => :((_1).mode)
   :(%8) => :(ifelse(%3 === :dcop, 0.0, ifelse(%3 === :tranop, 0.0, %2)))
  :(%14) => :(ifelse(%3 === :dcop, 0.0, ifelse(%3 === :tranop, 0.0, %2)))
  :(%22) => :(ifelse(%8 < 0, 0.5, 0.5 + 1 * 1.0 * sind(360 * 1000.0 * (%14 - 0) + 0)))
  :(%26) => :(ifelse(%3 === :dcop, 0.0, %22))
  :(%30) => :(((0.0 - 0.0) - %26) / -1.0)
  :(%31) => :(solved_variable(1, %30))
  :(%32) => :((_1).params)
  :(%33) => :((%32).backing)
  :(%35) => :(variable(nothing))
  :(%36) => :(%35)
  :(%38) => :(%30 - %36)
  :(%42) => :((0.0 - %38 / (%33).r1) / -1.0)
  :(%43) => :(solved_variable(6, %42))
  :(%46) => :(solved_variable(5, (1.0 * %42) / -1.0))
  :(%49) => :(%36 - 0.0)
  :(%53) => :((0.0 - %49 / (%33).r2) / -1.0)
  :(%54) => :(solved_variable(7, %53))
  :(%59) => :(solved_variable(3, (-1.0 * %42 + 1.0 * %53) / -1.0))
  :(%68) => :(equation(nothing))
  :(%69) => :((%68)(-1.0 * %42 + 1.0 * %53))
  :(%70) => :(goto %3 if not %5)
  :(%71) => :(goto %6)
  :(%72) => :(goto %5 if not %6)
  :(%73) => :(goto %6)
  :(%74) => :(goto %6)
  :(%75) => :(goto %8 if not %10)
  :(%76) => :(goto %14)
  :(%77) => :(goto %10 if not %11)
  :(%78) => :(goto %13)
  :(%79) => :(goto %12 if not %12)
  :(%80) => :(goto %13)
  :(%81) => :(goto %13)
  :(%82) => :(goto %14)
  :(%87) => :(observed!(%30 - 0.0, nothing, 1))
  :(%88) => :(goto %16 if not %25)
  :(%89) => :(goto %17)
  :(%95) => :(observed!(%38, nothing, 2))
 :(%100) => :(observed!(%49, nothing, 3))
 :(%102) => :(return nothing)
```
 
 You can see we do screw gotos as I mentioned